### PR TITLE
Add user controllers and services (foundation for user-based knowledge base)

### DIFF
--- a/src/main/java/com/vaibhav/knowledgebase/controller/UserController.java
+++ b/src/main/java/com/vaibhav/knowledgebase/controller/UserController.java
@@ -1,0 +1,44 @@
+package com.vaibhav.knowledgebase.controller;
+
+import com.vaibhav.knowledgebase.entity.User;
+import com.vaibhav.knowledgebase.services.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/user")
+public class UserController {
+    private UserService userService;
+
+    public UserController(UserService userService){
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<User> createUser(@Valid @RequestBody User user){
+        User createdUser = userService.createUser(user);
+        return new ResponseEntity<>(createdUser, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<User>> getAllUsers(){
+        List<User> users = userService.getAllUsers();
+        return ResponseEntity.ok(users);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<User> getUserById(@PathVariable Long id){
+        return userService.getUserById(id).map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/username/{username}")
+    public ResponseEntity<User> getUserByUsername(@PathVariable String username) {
+        return userService.getUserByUsername(username)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/com/vaibhav/knowledgebase/entity/KnowledgeBase.java
+++ b/src/main/java/com/vaibhav/knowledgebase/entity/KnowledgeBase.java
@@ -9,18 +9,24 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "knowledge_base")
 @Data
+
 public class KnowledgeBase {
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
 
     @NotBlank(message = "Topic must not be empty")
     @Column(nullable = false)
     private String topic;
 
     @NotBlank(message = "Explanation must not be empty")
-    @Column(nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false , columnDefinition = "TEXT")
     private String explanation;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/vaibhav/knowledgebase/entity/User.java
+++ b/src/main/java/com/vaibhav/knowledgebase/entity/User.java
@@ -1,0 +1,41 @@
+package com.vaibhav.knowledgebase.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@Table(name = "users")
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @NotBlank(message = "username must not be empty")
+    @Column(unique = true, nullable = false)
+    private String username;
+
+    @NotBlank(message = "email must not be empty")
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @NotBlank(message = "password must not be empty")
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/vaibhav/knowledgebase/repository/UserRepository.java
+++ b/src/main/java/com/vaibhav/knowledgebase/repository/UserRepository.java
@@ -1,0 +1,19 @@
+package com.vaibhav.knowledgebase.repository;
+
+import com.vaibhav.knowledgebase.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+    @Repository
+    public interface UserRepository extends JpaRepository<User, Long> {
+
+        Optional<User> findByUsername(String username);
+
+        Optional<User> findByEmail(String email);
+
+        boolean existsByUsername(String username);
+
+        boolean existsByEmail(String email);
+    }

--- a/src/main/java/com/vaibhav/knowledgebase/services/UserService.java
+++ b/src/main/java/com/vaibhav/knowledgebase/services/UserService.java
@@ -1,0 +1,41 @@
+package com.vaibhav.knowledgebase.services;
+
+import com.vaibhav.knowledgebase.entity.User;
+import com.vaibhav.knowledgebase.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class UserService {
+    private final UserRepository userRepository;
+    public UserService(UserRepository userRepository){
+        this.userRepository =  userRepository;
+    }
+
+    public User createUser(User user){
+        if (userRepository.existsByUsername(user.getUsername())){
+            throw new RuntimeException("Username taken");
+        }
+        if (userRepository.existsByEmail(user.getEmail())){
+            throw new RuntimeException("email already in use");
+        }
+        return userRepository.save(user);
+    }
+
+    public List<User> getAllUsers() {
+        return userRepository.findAll();
+    }
+
+
+    public Optional<User> getUserById(Long id) {
+        return userRepository.findById(id);
+    }
+
+
+    public Optional<User> getUserByUsername(String username) {
+        return userRepository.findByUsername(username);
+    }
+
+}


### PR DESCRIPTION
### What this PR does
- Introduces User controller, service, and related layers
- Adds basic user-side request handling and structure
- Establishes foundation required for user-scoped data access

### What is NOT included (intentional)
- This PR intentionally stops before database integration to avoid mixing
   domain setup with persistence logic. DB wiring will follow in a separate PR.


### Why this change
- Separates user-domain setup from database wiring
- Keeps PR small and reviewable
- Prepares clean base for upcoming relational mapping work

### Next steps
- Connect users to knowledge_base DB
- Implement user_id foreign key relationships
- Enforce per-user data isolation at repository level
