### PR TITLE
Refactor Knowledge Base API to use DTO-based request/response models

### DIFF
--- a/src/main/java/com/vaibhav/knowledgebase/controller/KnowledgeBaseController.java
+++ b/src/main/java/com/vaibhav/knowledgebase/controller/KnowledgeBaseController.java
@@ -1,5 +1,7 @@
 package com.vaibhav.knowledgebase.controller;
 
+import com.vaibhav.knowledgebase.dto.KnowledgeBaseRequest;
+import com.vaibhav.knowledgebase.dto.KnowledgeBaseResponse;
 import com.vaibhav.knowledgebase.entity.KnowledgeBase;
 import com.vaibhav.knowledgebase.services.KnowledgeBaseService;
 import jakarta.validation.Valid;
@@ -15,21 +17,18 @@ import java.time.LocalDateTime;
 public class KnowledgeBaseController {
 
     private final KnowledgeBaseService knowledgeBaseService;
-
     public KnowledgeBaseController(KnowledgeBaseService knowledgeBaseService) {
         this.knowledgeBaseService = knowledgeBaseService;
     }
 
+
     @PostMapping("/{userId}/knowledge-base")
-    public KnowledgeBase createEntry(@Valid @RequestBody KnowledgeBase myEntry, @PathVariable long userId) {
-        myEntry.setCreatedAt(LocalDateTime.now());
-        knowledgeBaseService.saveEntry(myEntry, userId);
-        return myEntry;
+    public KnowledgeBaseResponse createEntry(@Valid @RequestBody KnowledgeBaseRequest request, @PathVariable long userId) {
+        return knowledgeBaseService.createEntry(request, userId);
     }
 
     @GetMapping("/{userId}/knowledge-base")
-    public List<KnowledgeBase> getAll(
-            @PathVariable long userId) {
+    public List<KnowledgeBaseResponse> getAll(@PathVariable long userId) {
         return knowledgeBaseService.getByUser(userId);
     }
 
@@ -39,7 +38,7 @@ public class KnowledgeBaseController {
     }
 
     @PutMapping("/{userId}/knowledge-base/{id}")
-    public KnowledgeBase updateEntryById(@PathVariable long userId, @PathVariable Long id, @RequestBody KnowledgeBase myEntry) {
-        return knowledgeBaseService.updateEntry(id, userId, myEntry);
+    public KnowledgeBaseResponse update(@PathVariable long userId, @PathVariable Long id, @RequestBody KnowledgeBaseRequest request) {
+        return knowledgeBaseService.updateEntry(id, userId, request);
     }
 }

--- a/src/main/java/com/vaibhav/knowledgebase/dto/KnowledgeBaseRequest.java
+++ b/src/main/java/com/vaibhav/knowledgebase/dto/KnowledgeBaseRequest.java
@@ -1,0 +1,11 @@
+package com.vaibhav.knowledgebase.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KnowledgeBaseRequest(
+        @NotBlank String topic,
+        @NotBlank String explanation,
+        String example,
+        @NotBlank String category
+
+) {}

--- a/src/main/java/com/vaibhav/knowledgebase/dto/KnowledgeBaseResponse.java
+++ b/src/main/java/com/vaibhav/knowledgebase/dto/KnowledgeBaseResponse.java
@@ -1,0 +1,16 @@
+package com.vaibhav.knowledgebase.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+
+public record KnowledgeBaseResponse(
+        Long id,
+        String topic,
+        String explanation,
+        String example,
+        String category,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {}
+


### PR DESCRIPTION
### Summary
This PR refactors the Knowledge Base API to use explicit DTOs for all request and response payloads. 
Controllers no longer expose JPA entities directly; instead, request/response DTOs are used to decouple
the external API contract from the persistence layer.

### Key Changes
- Added `KnowledgeBaseRequest` and `KnowledgeBaseResponse` DTOs
- Refactored KnowledgeBase service methods to map between DTOs and entities
- Updated controllers to accept and return DTOs only
- Preserved all existing functionality (CRUD, ownership checks, validation)
- Improved API safety by preventing entity leakage

### Why This Change?
- Prevents accidental exposure of internal JPA entities
- Makes the API contract stable and explicit
- Simplifies future enhancements (JWT authentication, pagination, search)
- Aligns the codebase with production-grade Spring Boot best practices

### Testing
- Manually tested all CRUD endpoints via Postman
- Verified multi-user isolation and ownership enforcement
- Confirmed validation errors are correctly returned for invalid DTO input

### Notes
- No database schema changes were required
- This refactor is backward-compatible in behavior (only response/request shapes changed)
